### PR TITLE
[Do Not Merge] Adding sample code for auth using azure credentials.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,11 @@
             <artifactId>slf4j-simple</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-identity</artifactId>
+            <version>1.2.2</version>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>

--- a/src/main/java/com/azure/cosmos/springexamples/quickstart/sync/SampleAppConfiguration.java
+++ b/src/main/java/com/azure/cosmos/springexamples/quickstart/sync/SampleAppConfiguration.java
@@ -4,6 +4,8 @@ package com.azure.cosmos.springexamples.quickstart.sync;
 
 import com.azure.cosmos.CosmosClientBuilder;
 import com.azure.cosmos.DirectConnectionConfig;
+import com.azure.identity.DefaultAzureCredential;
+import com.azure.identity.DefaultAzureCredentialBuilder;
 import com.azure.spring.data.cosmos.config.AbstractCosmosConfiguration;
 import com.azure.spring.data.cosmos.config.CosmosConfig;
 import com.azure.spring.data.cosmos.core.ResponseDiagnostics;
@@ -33,10 +35,15 @@ public class SampleAppConfiguration extends AbstractCosmosConfiguration {
     @Bean
     public CosmosClientBuilder cosmosClientBuilder() {
         DirectConnectionConfig directConnectionConfig = DirectConnectionConfig.getDefaultConfig();
+        // DefaultAzureCredential uses environment variables as explained in the below link to build corresponding
+        // credential. For example setting the environment variables AZURE_CLIENT_ID, AZURE_USERNAME, AZURE_PASSWORD
+        // will create a UsernamePasswordCredential. Read the link below for further info
+        // https://docs.microsoft.com/en-us/java/api/overview/azure/identity-readme?view=azure-java-stable#service-principal-with-secret
+        DefaultAzureCredential credential = new DefaultAzureCredentialBuilder().build();
         return new CosmosClientBuilder()
-            .endpoint(properties.getUri())
-            .key(properties.getKey())
-            .directMode(directConnectionConfig);
+                       .endpoint(properties.getUri())
+                       .credential(credential)
+                       .directMode(directConnectionConfig);
     }
 
     @Bean

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 cosmos.uri=${ACCOUNT_HOST}
-cosmos.key=${ACCOUNT_KEY}
+# cosmos.key=${ACCOUNT_KEY} -- Not necessary when using Azure identity credentials
 cosmos.secondaryKey=${SECONDARY_ACCOUNT_KEY}
 
 dynamic.collection.name=spel-property-collection


### PR DESCRIPTION
Sample code to demo the AAD based authentication
- Step 1) Add azure identity dependency
Example:
        <dependency>
            <groupId>com.azure</groupId>
            <artifactId>azure-identity</artifactId>
            <version>1.2.2</version>
        </dependency>

- Step 2) Define environment variables as per requirement as defined here
https://docs.microsoft.com/en-us/java/api/overview/azure/identity-readme?view=azure-java-stable#service-principal-with-secret
And create a default credential as required
DefaultAzureCredential credential = new DefaultAzureCredentialBuilder().build();
and pass it to the CosmosClientBuilder() using .credential()
```java
    @Bean
    public CosmosClientBuilder cosmosClientBuilder() {
        DefaultAzureCredential credential = new DefaultAzureCredentialBuilder().build();
        return new CosmosClientBuilder()
                       .endpoint(properties.getUri())
                       .credential(credential)
                       .directMode(directConnectionConfig);
    }
```
Note:
Make sure you use an existing database and container and supply them to the config accordingly as RBAC auth may be  able work only on document operations.


** Do not merge this code into this sample until we  create a new sample for demonstrating above and then we can put this code there



